### PR TITLE
vendor: move HAVOC_BASE_VERSION logic to android_build [2/2]

### DIFF
--- a/core/build_id.mk
+++ b/core/build_id.mk
@@ -19,3 +19,4 @@
 # capitalized by convention.
 
 export BUILD_ID=PQ2A.190305.002
+export HAVOC_BASE_VERSION=2.3

--- a/tools/buildinfo.sh
+++ b/tools/buildinfo.sh
@@ -62,5 +62,6 @@ fi
 echo "ro.build.characteristics=$TARGET_AAPT_CHARACTERISTICS"
 
 echo "ro.havoc.device=$HAVOC_DEVICE"
+echo "ro.havoc.base.version=$HAVOC_BASE_VERSION"
 
 echo "# end build properties"

--- a/tools/vendor_buildinfo.sh
+++ b/tools/vendor_buildinfo.sh
@@ -18,5 +18,6 @@ echo "ro.product.vendor.model=$PRODUCT_MODEL"
 echo "ro.product.vendor.brand=$PRODUCT_BRAND"
 echo "ro.product.vendor.name=$PRODUCT_NAME"
 echo "ro.product.vendor.device=$TARGET_DEVICE"
+echo "ro.havoc.base.version=$HAVOC_BASE_VERSION"
 
 echo "# end build properties"


### PR DESCRIPTION
* Fixes .json file output of "version" for Treble Devices