### PR TITLE
build: Allow mounting system properly for A-only system-as-root devices

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -343,12 +343,15 @@ def LoadRecoveryFSTab(read_helper, fstab_version, recovery_fstab_path,
         d[mount_point] = Partition(mount_point=mount_point, fs_type=pieces[2],
                                    device=pieces[0], length=length, context=context)
 
+  global system_as_system
+  system_as_system = True
   # / is used for the system mount point when the root directory is included in
   # system. Other areas assume system is always at "/system" so point /system
   # at /.
   if system_root_image:
-    assert not d.has_key("/system") and d.has_key("/")
-    d["/system"] = d["/"]
+    if not d.has_key("/system"):
+      system_as_system = False
+      d["/system"] = d["/"]
   return d
 
 

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -820,7 +820,13 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   # Dump fingerprints
   script.Print("Target: {}".format(target_info.fingerprint))
 
-  script.AppendExtra("ifelse(is_mounted(\"/system\"), unmount(\"/system\"));")
+  is_system_as_root = target_info.get("system_root_image") == "true"
+  if is_system_as_root and not common.system_as_system:
+    system_mount_point = "/system_root"
+  else:
+    system_mount_point = "/system"
+
+  script.AppendExtra("ifelse(is_mounted(\"{0}\"), unmount(\"{0}\"));".format(system_mount_point))
   device_specific.FullOTA_InstallBegin()
 
   CopyInstallTools(output_zip)
@@ -829,12 +835,14 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   script.SetPermissionsRecursive("/tmp/install/bin", 0, 0, 0755, 0755, None, None)
 
   if OPTIONS.backuptool:
-    is_system_as_root = script.fstab["/system"].mount_point == "/"
     if is_system_as_root:
-      script.fstab["/system"].mount_point = "/system"
+      script.fstab["/system"].mount_point = system_mount_point
     script.Mount("/system")
-    script.RunBackup("backup", "/system/system" if is_system_as_root else "/system")
-    script.Unmount("/system")
+    if is_system_as_root and common.system_as_system:
+      script.RunBackup("backup", "/system/system")
+    else:
+      script.RunBackup("backup", "/system")
+    script.Unmount(system_mount_point)
     if is_system_as_root:
       script.fstab["/system"].mount_point = "/"
 
@@ -907,12 +915,14 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
 
   if OPTIONS.backuptool:
     script.ShowProgress(0.02, 10)
-    is_system_as_root = script.fstab["/system"].mount_point == "/"
     if is_system_as_root:
-      script.fstab["/system"].mount_point = "/system"
+      script.fstab["/system"].mount_point = system_mount_point
     script.Mount("/system")
-    script.RunBackup("restore", "/system/system" if is_system_as_root else "/system")
-    script.Unmount("/system")
+    if is_system_as_root and common.system_as_system:
+      script.RunBackup("restore", "/system/system")
+    else:
+      script.RunBackup("restore", "/system")
+    script.Unmount(system_mount_point)
     if is_system_as_root:
       script.fstab["/system"].mount_point = "/"
 


### PR DESCRIPTION
 * By AOSP build system and recovery design, A-only system-as-root
   image should be mounted at /system_root and /system is a symlink
   to /system_root/system.
 * Still allow mounting system to /system for system-as-root using a variable for devices that eventually need this

Change-Id: I4184c572b25faa8d1990e32f625fa814cba6690f