### PR TITLE
build: Exclude generic libnfc-nci.conf

### DIFF
--- a/target/product/aosp_product.mk
+++ b/target/product/aosp_product.mk
@@ -39,14 +39,14 @@ PRODUCT_PACKAGES += \
     preinstalled-packages-platform-aosp-product.xml \
     WallpaperPicker \
 
+ifeq ($(HAVOC_BUILD),)
 # Telephony:
 #   Provide a APN configuration to GSI product
-ifeq ($(HAVOC_BUILD),)
 PRODUCT_COPY_FILES += \
     device/sample/etc/apns-full-conf.xml:$(TARGET_COPY_OUT_PRODUCT)/etc/apns-conf.xml
-endif
 
 # NFC:
 #   Provide a libnfc-nci.conf to GSI product
 PRODUCT_COPY_FILES += \
     device/generic/common/nfc/libnfc-nci.conf:$(TARGET_COPY_OUT_PRODUCT)/etc/libnfc-nci.conf
+endif


### PR DESCRIPTION
This is overwriting the device specific config.

Change-Id: I0f07c17951b9b186349a9a96bf2fad1208d86ab1